### PR TITLE
fix #17: sender behavior for notifications

### DIFF
--- a/basic-application/basic-application-core/src/main/resources/configuration-env-default.properties
+++ b/basic-application/basic-application-core/src/main/resources/configuration-env-default.properties
@@ -32,7 +32,8 @@ environment.security.password.recovery.request.expiration.minutes=60
 environment.security.password.validator.enabled=true
 
 # Notification
-environment.notification.mail.sender=noreply@kobalt.fr
+environment.notification.mail.sender=EXPLICIT
+environment.notification.mail.sender=
 environment.notification.mail.from=Basic Application <noreply@kobalt.fr>
 environment.notification.mail.subjectPrefix=[Basic Application]
 environment.notification.smtp.host=smtp.accelance.net

--- a/basic-application/basic-application-core/src/main/resources/configuration.properties
+++ b/basic-application/basic-application-core/src/main/resources/configuration.properties
@@ -75,6 +75,8 @@ security.password.user.forbiddenPasswords=123456 123456789 654321 987654321 azer
 ##
 ## Notification
 ##
+# One of EXPLICIT, FALLBACK_TO_FROM, FALLBACK_TO_CONFIGURATION (cf MailSenderBehavior)
+notification.mail.sender.behavior=${environment.notification.mail.sender.behavior}
 notification.mail.sender=${environment.notification.mail.sender}
 notification.mail.from=${environment.notification.mail.from}
 notification.mail.subjectPrefix=${environment.notification.mail.subjectPrefix}

--- a/igloo/igloo-components/igloo-component-spring/src/main/java/org/iglooproject/spring/config/spring/SpringApplicationPropertyRegistryConfig.java
+++ b/igloo/igloo-components/igloo-component-spring/src/main/java/org/iglooproject/spring/config/spring/SpringApplicationPropertyRegistryConfig.java
@@ -10,6 +10,7 @@ import static org.iglooproject.spring.property.SpringPropertyIds.NOTIFICATION_MA
 import static org.iglooproject.spring.property.SpringPropertyIds.NOTIFICATION_MAIL_FROM;
 import static org.iglooproject.spring.property.SpringPropertyIds.NOTIFICATION_MAIL_RECIPIENTS_FILTERED;
 import static org.iglooproject.spring.property.SpringPropertyIds.NOTIFICATION_MAIL_SENDER;
+import static org.iglooproject.spring.property.SpringPropertyIds.NOTIFICATION_MAIL_SENDER_BEHAVIOR;
 import static org.iglooproject.spring.property.SpringPropertyIds.NOTIFICATION_MAIL_SUBJECT_PREFIX;
 import static org.iglooproject.spring.property.SpringPropertyIds.NOTIFICATION_TEST_EMAILS;
 import static org.iglooproject.spring.property.SpringPropertyIds.TMP_EXPORT_EXCEL_PATH;
@@ -23,6 +24,7 @@ import java.util.Set;
 import org.iglooproject.functional.Suppliers2;
 import org.iglooproject.functional.converter.StringCollectionConverter;
 import org.iglooproject.functional.converter.StringLocaleConverter;
+import org.iglooproject.spring.config.util.MailSenderBehavior;
 import org.iglooproject.spring.property.SpringPropertyIds;
 import org.iglooproject.spring.property.service.IPropertyRegistry;
 import org.slf4j.Logger;
@@ -85,6 +87,7 @@ public class SpringApplicationPropertyRegistryConfig extends AbstractApplication
 		registry.registerString(NOTIFICATION_MAIL_FROM);
 		registry.registerString(NOTIFICATION_MAIL_SUBJECT_PREFIX);
 		registry.registerString(NOTIFICATION_MAIL_SENDER);
+		registry.registerEnum(NOTIFICATION_MAIL_SENDER_BEHAVIOR, MailSenderBehavior.class, MailSenderBehavior.EXPLICIT);
 		registry.registerBoolean(NOTIFICATION_MAIL_RECIPIENTS_FILTERED);
 		registry.register(NOTIFICATION_TEST_EMAILS, new StringCollectionConverter<String, List<String>>(Converter.<String>identity(), Suppliers2.<String>arrayList()), Lists.<String>newArrayList());
 		registry.register(NOTIFICATION_MAIL_DISABLED_RECIPIENT_FALLBACK, new StringCollectionConverter<String, List<String>>(Converter.<String>identity(), Suppliers2.<String>arrayList()), Lists.<String>newArrayList());

--- a/igloo/igloo-components/igloo-component-spring/src/main/java/org/iglooproject/spring/config/util/MailSenderBehavior.java
+++ b/igloo/igloo-components/igloo-component-spring/src/main/java/org/iglooproject/spring/config/util/MailSenderBehavior.java
@@ -1,0 +1,25 @@
+package org.iglooproject.spring.config.util;
+
+import org.iglooproject.spring.notification.service.NotificationBuilder;
+
+/**
+ * Behavior applicable when sender is not explicitly set on {@link NotificationBuilder}.
+ */
+public enum MailSenderBehavior {
+
+	/**
+	 * Sender set from configuration.
+	 */
+	FALLBACK_TO_CONFIGURATION,
+
+	/**
+	 * Sender set from notification From: value.
+	 */
+	FALLBACK_TO_FROM,
+
+	/**
+	 * Sender not modified on NotificationBuilder. Empty values are kept unset.
+	 */
+	EXPLICIT;
+
+}

--- a/igloo/igloo-components/igloo-component-spring/src/main/java/org/iglooproject/spring/property/SpringPropertyIds.java
+++ b/igloo/igloo-components/igloo-component-spring/src/main/java/org/iglooproject/spring/property/SpringPropertyIds.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
+import org.iglooproject.spring.config.util.MailSenderBehavior;
 import org.iglooproject.spring.property.model.AbstractPropertyIds;
 import org.iglooproject.spring.property.model.ImmutablePropertyId;
 
@@ -43,6 +44,7 @@ public final class SpringPropertyIds extends AbstractPropertyIds {
 	public static final ImmutablePropertyId<Locale> DEFAULT_LOCALE = immutable("locale.default");
 	
 	public static final ImmutablePropertyId<String> NOTIFICATION_MAIL_SENDER = immutable("notification.mail.sender");
+	public static final ImmutablePropertyId<MailSenderBehavior> NOTIFICATION_MAIL_SENDER_BEHAVIOR = immutable("notification.mail.sender.behavior");
 	public static final ImmutablePropertyId<String> NOTIFICATION_MAIL_FROM = immutable("notification.mail.from");
 	public static final ImmutablePropertyId<String> NOTIFICATION_MAIL_SUBJECT_PREFIX = immutable("notification.mail.subjectPrefix");
 	public static final ImmutablePropertyId<Boolean> NOTIFICATION_MAIL_RECIPIENTS_FILTERED = immutable("notification.mail.recipientsFiltered");

--- a/igloo/igloo-components/igloo-component-spring/src/test/java/org/iglooproject/test/spring/notification/AbstractTestNotification.java
+++ b/igloo/igloo-components/igloo-component-spring/src/test/java/org/iglooproject/test/spring/notification/AbstractTestNotification.java
@@ -2,9 +2,12 @@ package org.iglooproject.test.spring.notification;
 
 import javax.mail.internet.MimeMessage;
 
+import org.iglooproject.config.bootstrap.spring.ExtendedApplicationContextInitializer;
 import org.iglooproject.spring.notification.service.INotificationBuilderBaseState;
 import org.iglooproject.spring.notification.service.NotificationBuilder;
+import org.iglooproject.test.spring.notification.spring.config.TestConfig;
 import org.junit.Before;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.verification.VerificationMode;
@@ -12,9 +15,26 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 
+@RunWith(SpringJUnit4ClassRunner.class)
+@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class })
+@ContextConfiguration(
+		classes = { TestConfig.class },
+		initializers = { ExtendedApplicationContextInitializer.class }
+)
+@TestPropertySource(properties = {
+		"notification.mail.sender.behavior=EXPLICIT",
+		"notification.mail.from=" + AbstractTestNotification.CONFIG_FROM
+})
 public abstract class AbstractTestNotification {
-	
+
+	protected static final String CONFIG_FROM = "Example From <from-config@example.com>";
+
 	@Autowired
 	private ApplicationContext applicationContext;
 

--- a/igloo/igloo-components/igloo-component-spring/src/test/java/org/iglooproject/test/spring/notification/TestNotificationFiltered.java
+++ b/igloo/igloo-components/igloo-component-spring/src/test/java/org/iglooproject/test/spring/notification/TestNotificationFiltered.java
@@ -10,28 +10,20 @@ import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMessage.RecipientType;
 
 import org.assertj.core.api.Assertions;
-import org.iglooproject.config.bootstrap.spring.ExtendedApplicationContextInitializer;
 import org.iglooproject.jpa.exception.ServiceException;
 import org.iglooproject.spring.notification.service.INotificationBuilderBaseState;
 import org.iglooproject.spring.property.SpringPropertyIds;
 import org.iglooproject.spring.property.service.IPropertyService;
-import org.iglooproject.test.spring.notification.spring.config.TestConfig;
 import org.iglooproject.test.spring.notification.spring.config.TestFilteredConfig;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class })
 @ContextConfiguration(
-		classes = { TestConfig.class, TestFilteredConfig.class },
-		initializers = { ExtendedApplicationContextInitializer.class }
+		classes = { TestFilteredConfig.class },
+		inheritInitializers = true
 )
 public class TestNotificationFiltered extends AbstractTestNotification {
 

--- a/igloo/igloo-components/igloo-component-spring/src/test/java/org/iglooproject/test/spring/notification/TestNotificationSenderExplicit.java
+++ b/igloo/igloo-components/igloo-component-spring/src/test/java/org/iglooproject/test/spring/notification/TestNotificationSenderExplicit.java
@@ -1,0 +1,54 @@
+package org.iglooproject.test.spring.notification;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+
+import org.assertj.core.api.Assertions;
+import org.iglooproject.jpa.exception.ServiceException;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = {
+		"notification.mail.sender.behavior=EXPLICIT",
+		"notification.mail.sender=overriden-sender@example.com"
+})
+public class TestNotificationSenderExplicit extends AbstractTestNotification {
+
+	@Test
+	public void testNotificationSenderUnset() throws ServiceException, MessagingException {
+		createNotificationBuilder().from("from@example.com").toAddress("to@example.com")
+			.subject("subject").textBody("text").send();
+		MimeMessage message = mockitoSend(Mockito.times(1)).getValue();
+		Assertions.assertThat(message.getFrom()).containsExactly(new InternetAddress("from@example.com"));
+		Assertions.assertThat(message.getSender()).isNull();
+	}
+
+	@Test
+	public void testNotificationSenderSet() throws ServiceException, MessagingException {
+		createNotificationBuilder().sender("sender@example.com").from("from@example.com").toAddress("to@example.com")
+			.subject("subject").textBody("text").send();
+		MimeMessage message = mockitoSend(Mockito.times(1)).getValue();
+		Assertions.assertThat(message.getFrom()).containsExactly(new InternetAddress("from@example.com"));
+		Assertions.assertThat(message.getSender()).isEqualTo(new InternetAddress("sender@example.com"));
+	}
+
+	@Test
+	public void testNotificationDefaultFromSenderSet() throws ServiceException, MessagingException {
+		createNotificationBuilder().sender("sender@example.com").toAddress("to@example.com")
+			.subject("subject").textBody("text").send();
+		MimeMessage message = mockitoSend(Mockito.times(1)).getValue();
+		Assertions.assertThat(message.getFrom()).containsExactly(new InternetAddress(CONFIG_FROM));
+		Assertions.assertThat(message.getSender()).isEqualTo(new InternetAddress("sender@example.com"));
+	}
+
+	@Test
+	public void testNotificationDefaultFromSenderUnset() throws ServiceException, MessagingException {
+		createNotificationBuilder().toAddress("to@example.com")
+			.subject("subject").textBody("text").send();
+		MimeMessage message = mockitoSend(Mockito.times(1)).getValue();
+		Assertions.assertThat(message.getFrom()).containsExactly(new InternetAddress(CONFIG_FROM));
+		Assertions.assertThat(message.getSender()).isNull();
+	}
+}

--- a/igloo/igloo-components/igloo-component-spring/src/test/java/org/iglooproject/test/spring/notification/TestNotificationSenderFallbackToConfiguration.java
+++ b/igloo/igloo-components/igloo-component-spring/src/test/java/org/iglooproject/test/spring/notification/TestNotificationSenderFallbackToConfiguration.java
@@ -1,0 +1,57 @@
+package org.iglooproject.test.spring.notification;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+
+import org.assertj.core.api.Assertions;
+import org.iglooproject.jpa.exception.ServiceException;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = {
+		"notification.mail.sender.behavior=FALLBACK_TO_CONFIGURATION",
+		"notification.mail.sender=" + TestNotificationSenderFallbackToConfiguration.CONFIG_SENDER
+})
+public class TestNotificationSenderFallbackToConfiguration extends AbstractTestNotification {
+
+	protected static final String CONFIG_SENDER = "Sender Example <sender-config@example.com>";
+
+	@Test
+	public void testNotificationSenderUnset() throws ServiceException, MessagingException {
+		createNotificationBuilder().from("from@example.com").toAddress("to@example.com")
+			.subject("subject").textBody("text").send();
+		MimeMessage message = mockitoSend(Mockito.times(1)).getValue();
+		Assertions.assertThat(message.getFrom()).containsExactly(new InternetAddress("from@example.com"));
+		Assertions.assertThat(message.getSender()).isEqualTo(new InternetAddress(CONFIG_SENDER));
+	}
+
+	@Test
+	public void testNotificationSenderSet() throws ServiceException, MessagingException {
+		createNotificationBuilder().sender("sender@example.com").from("from@example.com").toAddress("to@example.com")
+			.subject("subject").textBody("text").send();
+		MimeMessage message = mockitoSend(Mockito.times(1)).getValue();
+		Assertions.assertThat(message.getFrom()).containsExactly(new InternetAddress("from@example.com"));
+		Assertions.assertThat(message.getSender()).isEqualTo(new InternetAddress("sender@example.com"));
+	}
+
+	@Test
+	public void testNotificationDefaultFromSenderSet() throws ServiceException, MessagingException {
+		createNotificationBuilder().sender("sender@example.com").toAddress("to@example.com")
+			.subject("subject").textBody("text").send();
+		MimeMessage message = mockitoSend(Mockito.times(1)).getValue();
+		Assertions.assertThat(message.getFrom()).containsExactly(new InternetAddress(CONFIG_FROM));
+		Assertions.assertThat(message.getSender()).isEqualTo(new InternetAddress("sender@example.com"));
+	}
+
+	@Test
+	public void testNotificationDefaultFromSenderUnset() throws ServiceException, MessagingException {
+		createNotificationBuilder().toAddress("to@example.com")
+			.subject("subject").textBody("text").send();
+		MimeMessage message = mockitoSend(Mockito.times(1)).getValue();
+		Assertions.assertThat(message.getFrom()).containsExactly(new InternetAddress(CONFIG_FROM));
+		Assertions.assertThat(message.getSender()).isEqualTo(new InternetAddress(CONFIG_SENDER));
+	}
+
+}

--- a/igloo/igloo-components/igloo-component-spring/src/test/java/org/iglooproject/test/spring/notification/TestNotificationSenderFallbackToFrom.java
+++ b/igloo/igloo-components/igloo-component-spring/src/test/java/org/iglooproject/test/spring/notification/TestNotificationSenderFallbackToFrom.java
@@ -1,0 +1,52 @@
+package org.iglooproject.test.spring.notification;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+
+import org.assertj.core.api.Assertions;
+import org.iglooproject.jpa.exception.ServiceException;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = {"notification.mail.sender.behavior=FALLBACK_TO_FROM"})
+public class TestNotificationSenderFallbackToFrom extends AbstractTestNotification {
+
+	@Test
+	public void testNotificationSenderUnset() throws ServiceException, MessagingException {
+		createNotificationBuilder().from("from@example.com").toAddress("to@example.com")
+			.subject("subject").textBody("text").send();
+		MimeMessage message = mockitoSend(Mockito.times(1)).getValue();
+		Assertions.assertThat(message.getFrom()).containsExactly(new InternetAddress("from@example.com"));
+		Assertions.assertThat(message.getSender()).isEqualTo(new InternetAddress("from@example.com"));
+	}
+
+	@Test
+	public void testNotificationSenderSet() throws ServiceException, MessagingException {
+		createNotificationBuilder().sender("sender@example.com").from("from@example.com").toAddress("to@example.com")
+			.subject("subject").textBody("text").send();
+		MimeMessage message = mockitoSend(Mockito.times(1)).getValue();
+		Assertions.assertThat(message.getFrom()).containsExactly(new InternetAddress("from@example.com"));
+		Assertions.assertThat(message.getSender()).isEqualTo(new InternetAddress("sender@example.com"));
+	}
+
+	@Test
+	public void testNotificationDefaultFromSenderSet() throws ServiceException, MessagingException {
+		createNotificationBuilder().sender("sender@example.com").toAddress("to@example.com")
+			.subject("subject").textBody("text").send();
+		MimeMessage message = mockitoSend(Mockito.times(1)).getValue();
+		Assertions.assertThat(message.getFrom()).containsExactly(new InternetAddress(CONFIG_FROM));
+		Assertions.assertThat(message.getSender()).isEqualTo(new InternetAddress("sender@example.com"));
+	}
+
+	@Test
+	public void testNotificationDefaultFromSenderUnset() throws ServiceException, MessagingException {
+		createNotificationBuilder().toAddress("to@example.com")
+			.subject("subject").textBody("text").send();
+		MimeMessage message = mockitoSend(Mockito.times(1)).getValue();
+		Assertions.assertThat(message.getFrom()).containsExactly(new InternetAddress(CONFIG_FROM));
+		Assertions.assertThat(message.getSender()).isEqualTo(new InternetAddress(CONFIG_FROM));
+	}
+
+}

--- a/igloo/igloo-components/igloo-component-spring/src/test/resources/notification-test.properties
+++ b/igloo/igloo-components/igloo-component-spring/src/test/resources/notification-test.properties
@@ -4,7 +4,8 @@ configurationType=deployment
 locale.default=fr
 locale.availableLocales=fr en
 
-notification.mail.from=Example From <from@example.com>
+# Set with @PropertySources
+# notification.mail.from=
 notification.mail.subjectPrefix=[Test Igloo]
 notification.smtp.host=smtp.example.com
 notification.smtp.port=25


### PR DESCRIPTION
New configuration ``notification.mail.sender.behavior`` to control
sender notification setting when it is not explicitly set on the
notification builder.

* EXPLICIT: nothing is done. If sender is not set, no sender is passed to
  Java API
* FALLBACK_TO_CONFIGURATION: if sender is not set, value from
  ``notification.mail.sender`` is used
* FALLBACK_TO_FROM: if sender is not set, from value is used to set sender

From now, sender() accept RFC822 addresses (Personal <local@domain>),
just like from() method.