### PR TITLE
SecurePackageResourceGuard: allow *.webmanifest

### DIFF
--- a/igloo/igloo-components/igloo-component-wicket-more/src/main/java/org/iglooproject/wicket/more/application/CoreWicketApplication.java
+++ b/igloo/igloo-components/igloo-component-wicket-more/src/main/java/org/iglooproject/wicket/more/application/CoreWicketApplication.java
@@ -114,6 +114,7 @@ public abstract class CoreWicketApplication extends WebApplication {
 		packageResourceGuard.addPattern("+*.less");
 		packageResourceGuard.addPattern("+*.scss");
 		packageResourceGuard.addPattern("+*.json");
+		packageResourceGuard.addPattern("+*.webmanifest");
 		
 		// la compression se fait au build quand c'est nécessaire ; on n'utilise pas la compression Wicket
 		getResourceSettings().setJavaScriptCompressor(new NoOpTextCompressor());


### PR DESCRIPTION
site.webmanifest is a file used to setup favicon and application icons.

Currently, if a link rel="manifest" is used, and file delivery is done
by wicket package resource, wicket forbids file access with the
following error :

```
WARN  - SecurePackageResourceGuard - /site.webmanifest - Access denied to shared (static) resource: fr/arcep/jalerte/web/application/front/common/template/favicon/site.webmanifest
```

This commit adds an authorization to access this file via package resources
for all applications.

cf https://developer.mozilla.org/en-US/docs/Web/Manifest
cf https://ci.apache.org/projects/wicket/apidocs/8.x/org/apache/wicket/markup/html/SecurePackageResourceGuard.html

**We need to decide if this fix is done in a hotfix or a new release.**