### PR TITLE
issue:74 AbstractOfflinePanelRendererServiceImpl is broken with bootstrap component

### DIFF
--- a/basic-application/basic-application-core/pom.xml
+++ b/basic-application/basic-application-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>basic-application</artifactId>
 		<groupId>org.iglooproject.archetype</groupId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 	
 	<artifactId>basic-application-core</artifactId>

--- a/basic-application/basic-application-webapp/pom.xml
+++ b/basic-application/basic-application-webapp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>basic-application</artifactId>
 		<groupId>org.iglooproject.archetype</groupId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 	
 	<packaging>war</packaging>

--- a/basic-application/basic-application-webapp/src/main/java/org/iglooproject/basicapp/web/application/notification/service/BasicApplicationNotificationContentDescriptorFactoryImpl.java
+++ b/basic-application/basic-application-webapp/src/main/java/org/iglooproject/basicapp/web/application/notification/service/BasicApplicationNotificationContentDescriptorFactoryImpl.java
@@ -51,6 +51,10 @@ public class BasicApplicationNotificationContentDescriptorFactoryImpl
 			public Component createComponent(String wicketId) {
 				return new ExampleHtmlNotificationPanel(wicketId, GenericEntityModel.of(user), Model.of(date));
 			}
+			@Override
+			public Class<? extends Component> getComponentClass() {
+				return ExampleHtmlNotificationPanel.class;
+			}
 		};
 	}
 
@@ -87,6 +91,10 @@ public class BasicApplicationNotificationContentDescriptorFactoryImpl
 					userModel, userModel, Model.of(new Date()),
 					mapper.map(userModel, BindingModel.of(userModel, Bindings.user().passwordRecoveryRequest().token()))
 				);
+			}
+			@Override
+			public Class<? extends Component> getComponentClass() {
+				return UserPasswordRecoveryRequestHtmlNotificationPanel.class;
 			}
 		};
 	}

--- a/basic-application/pom.xml
+++ b/basic-application/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.iglooproject.parents</groupId>
 		<artifactId>igloo-parent-core-project</artifactId>
 		<relativePath>../igloo/igloo-parents/igloo-parent-core-project/pom.xml</relativePath>
-		<version>5.0.2</version><!-- KEEPME: archetype parent.version -->
+		<version>5.0.3-SNAPSHOT</version><!-- KEEPME: archetype parent.version -->
 	</parent>
 	
 	<groupId>org.iglooproject.archetype</groupId>

--- a/igloo/igloo-components/igloo-component-autoprefixer/pom.xml
+++ b/igloo/igloo-components/igloo-component-autoprefixer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-autoprefixer</artifactId>

--- a/igloo/igloo-components/igloo-component-bootstrap/pom.xml
+++ b/igloo/igloo-components/igloo-component-bootstrap/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-bootstrap</artifactId>

--- a/igloo/igloo-components/igloo-component-bootstrap/src/main/java/igloo/bootstrap/IBootstrap4Component.java
+++ b/igloo/igloo-components/igloo-component-bootstrap/src/main/java/igloo/bootstrap/IBootstrap4Component.java
@@ -1,0 +1,9 @@
+package igloo.bootstrap;
+
+/**
+ * Marker for root component during mail generation to choose the right bootstrap implementation for dynamic
+ * subcomponents.
+ */
+public interface IBootstrap4Component {
+
+}

--- a/igloo/igloo-components/igloo-component-bootstrap/src/main/java/igloo/bootstrap/IBootstrap4Page.java
+++ b/igloo/igloo-components/igloo-component-bootstrap/src/main/java/igloo/bootstrap/IBootstrap4Page.java
@@ -3,6 +3,6 @@ package igloo.bootstrap;
 /**
  * Marker interface for a bootstrap 4 page.
  */
-public interface IBootstrap4Page {
+public interface IBootstrap4Page extends IBootstrap4Component {
 
 }

--- a/igloo/igloo-components/igloo-component-bootstrap/src/main/java/igloo/bootstrap/IBootstrap5Component.java
+++ b/igloo/igloo-components/igloo-component-bootstrap/src/main/java/igloo/bootstrap/IBootstrap5Component.java
@@ -1,0 +1,9 @@
+package igloo.bootstrap;
+
+/**
+ * Marker for root component during mail generation to choose the right bootstrap implementation for dynamic
+ * subcomponents.
+ */
+public interface IBootstrap5Component {
+
+}

--- a/igloo/igloo-components/igloo-component-bootstrap/src/main/java/igloo/bootstrap/IBootstrap5Page.java
+++ b/igloo/igloo-components/igloo-component-bootstrap/src/main/java/igloo/bootstrap/IBootstrap5Page.java
@@ -3,6 +3,6 @@ package igloo.bootstrap;
 /**
  * Marker interface for a bootstrap 5 page.
  */
-public interface IBootstrap5Page {
+public interface IBootstrap5Page extends IBootstrap5Component {
 
 }

--- a/igloo/igloo-components/igloo-component-config-test/pom.xml
+++ b/igloo/igloo-components/igloo-component-config-test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-config-test</artifactId>

--- a/igloo/igloo-components/igloo-component-elasticsearch-plugin/pom.xml
+++ b/igloo/igloo-components/igloo-component-elasticsearch-plugin/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-elasticsearch-plugin</artifactId>

--- a/igloo/igloo-components/igloo-component-elasticsearch-test/pom.xml
+++ b/igloo/igloo-components/igloo-component-elasticsearch-test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-elasticsearch-test</artifactId>

--- a/igloo/igloo-components/igloo-component-export/pom.xml
+++ b/igloo/igloo-components/igloo-component-export/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 	
 	<artifactId>igloo-component-export</artifactId>

--- a/igloo/igloo-components/igloo-component-flyway/common/pom.xml
+++ b/igloo/igloo-components/igloo-component-flyway/common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/igloo/igloo-components/igloo-component-flyway/flyway-7/pom.xml
+++ b/igloo/igloo-components/igloo-component-flyway/flyway-7/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/igloo/igloo-components/igloo-component-flyway/flyway-8/pom.xml
+++ b/igloo/igloo-components/igloo-component-flyway/flyway-8/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/igloo/igloo-components/igloo-component-hibernate-configurator-api/pom.xml
+++ b/igloo/igloo-components/igloo-component-hibernate-configurator-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-hibernate-configurator-api</artifactId>

--- a/igloo/igloo-components/igloo-component-hibernate-configurator-elasticsearch/pom.xml
+++ b/igloo/igloo-components/igloo-component-hibernate-configurator-elasticsearch/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-hibernate-configurator-elasticsearch</artifactId>

--- a/igloo/igloo-components/igloo-component-hibernate-configurator-lucene/pom.xml
+++ b/igloo/igloo-components/igloo-component-hibernate-configurator-lucene/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-hibernate-configurator-lucene</artifactId>

--- a/igloo/igloo-components/igloo-component-imports/pom.xml
+++ b/igloo/igloo-components/igloo-component-imports/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 	
 	<artifactId>igloo-component-imports</artifactId>

--- a/igloo/igloo-components/igloo-component-jpa-migration/pom.xml
+++ b/igloo/igloo-components/igloo-component-jpa-migration/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 	
 	<artifactId>igloo-component-jpa-migration</artifactId>

--- a/igloo/igloo-components/igloo-component-jpa-more-test/pom.xml
+++ b/igloo/igloo-components/igloo-component-jpa-more-test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-jpa-more-test</artifactId>

--- a/igloo/igloo-components/igloo-component-jpa-more/pom.xml
+++ b/igloo/igloo-components/igloo-component-jpa-more/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-jpa-more</artifactId>

--- a/igloo/igloo-components/igloo-component-jpa-security/pom.xml
+++ b/igloo/igloo-components/igloo-component-jpa-security/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-jpa-security</artifactId>

--- a/igloo/igloo-components/igloo-component-jpa-test/pom.xml
+++ b/igloo/igloo-components/igloo-component-jpa-test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-jpa-test</artifactId>

--- a/igloo/igloo-components/igloo-component-jpa/pom.xml
+++ b/igloo/igloo-components/igloo-component-jpa/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-jpa</artifactId>

--- a/igloo/igloo-components/igloo-component-jul-to-slf4j/pom.xml
+++ b/igloo/igloo-components/igloo-component-jul-to-slf4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-jul-to-slf4j</artifactId>

--- a/igloo/igloo-components/igloo-component-lucene-analyzers/pom.xml
+++ b/igloo/igloo-components/igloo-component-lucene-analyzers/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-lucene-analyzers</artifactId>

--- a/igloo/igloo-components/igloo-component-rest-jersey2/pom.xml
+++ b/igloo/igloo-components/igloo-component-rest-jersey2/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-rest-jersey2</artifactId>

--- a/igloo/igloo-components/igloo-component-sass/pom.xml
+++ b/igloo/igloo-components/igloo-component-sass/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-sass</artifactId>

--- a/igloo/igloo-components/igloo-component-spring-bootstrap-config/pom.xml
+++ b/igloo/igloo-components/igloo-component-spring-bootstrap-config/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-spring-bootstrap-config</artifactId>

--- a/igloo/igloo-components/igloo-component-spring/pom.xml
+++ b/igloo/igloo-components/igloo-component-spring/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-spring</artifactId>

--- a/igloo/igloo-components/igloo-component-web-jpa-test/pom.xml
+++ b/igloo/igloo-components/igloo-component-web-jpa-test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-web-jpa-test</artifactId>

--- a/igloo/igloo-components/igloo-component-web-security/pom.xml
+++ b/igloo/igloo-components/igloo-component-web-security/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 	
 	<artifactId>igloo-component-web-security</artifactId>

--- a/igloo/igloo-components/igloo-component-web-test/pom.xml
+++ b/igloo/igloo-components/igloo-component-web-test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-web-test</artifactId>

--- a/igloo/igloo-components/igloo-component-wicket-bootstrap4/pom.xml
+++ b/igloo/igloo-components/igloo-component-wicket-bootstrap4/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-wicket-bootstrap4</artifactId>

--- a/igloo/igloo-components/igloo-component-wicket-bootstrap5/pom.xml
+++ b/igloo/igloo-components/igloo-component-wicket-bootstrap5/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-wicket-bootstrap5</artifactId>

--- a/igloo/igloo-components/igloo-component-wicket-console/pom.xml
+++ b/igloo/igloo-components/igloo-component-wicket-console/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-wicket-console</artifactId>

--- a/igloo/igloo-components/igloo-component-wicket-fontawesome/pom.xml
+++ b/igloo/igloo-components/igloo-component-wicket-fontawesome/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-wicket-fontawesome</artifactId>

--- a/igloo/igloo-components/igloo-component-wicket-jquery/pom.xml
+++ b/igloo/igloo-components/igloo-component-wicket-jquery/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-wicket-jquery</artifactId>

--- a/igloo/igloo-components/igloo-component-wicket-jqueryui/pom.xml
+++ b/igloo/igloo-components/igloo-component-wicket-jqueryui/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-wicket-jqueryui</artifactId>

--- a/igloo/igloo-components/igloo-component-wicket-more-jqplot/pom.xml
+++ b/igloo/igloo-components/igloo-component-wicket-more-jqplot/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 	<artifactId>igloo-component-wicket-more-jqplot</artifactId>
 	

--- a/igloo/igloo-components/igloo-component-wicket-more-test/pom.xml
+++ b/igloo/igloo-components/igloo-component-wicket-more-test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-wicket-more-test</artifactId>

--- a/igloo/igloo-components/igloo-component-wicket-more-test/src/test/java/test/wicket/more/notification/service/NotificationContentDescriptorFactoryImpl.java
+++ b/igloo/igloo-components/igloo-component-wicket-more-test/src/test/java/test/wicket/more/notification/service/NotificationContentDescriptorFactoryImpl.java
@@ -21,6 +21,11 @@ public class NotificationContentDescriptorFactoryImpl extends AbstractNotificati
 			public Component createComponent(String wicketId) {
 				return new CoreLabel(wicketId, Model.of(content)).setEscapeModelStrings(false);
 			}
+
+			@Override
+			public Class<? extends Component> getComponentClass() {
+				return CoreLabel.class;
+			}
 		};
 	}
 }

--- a/igloo/igloo-components/igloo-component-wicket-more/pom.xml
+++ b/igloo/igloo-components/igloo-component-wicket-more/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-wicket-more</artifactId>

--- a/igloo/igloo-components/igloo-component-wicket-more/src/main/java/org/iglooproject/wicket/more/notification/service/AbstractNotificationContentDescriptorFactory.java
+++ b/igloo/igloo-components/igloo-component-wicket-more/src/main/java/org/iglooproject/wicket/more/notification/service/AbstractNotificationContentDescriptorFactory.java
@@ -26,6 +26,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 
+import igloo.wicket.offline.IOfflineComponentProvider;
+
 public abstract class AbstractNotificationContentDescriptorFactory extends AbstractWicketRendererServiceImpl {
 	
 	private static final Logger LOGGER = LoggerFactory.getLogger(AbstractNotificationContentDescriptorFactory.class);
@@ -79,14 +81,18 @@ public abstract class AbstractNotificationContentDescriptorFactory extends Abstr
 			return renderHtmlBody(getDefaultLocale());
 		}
 		
+		@SuppressWarnings("unchecked")
 		private String renderHtmlBody(Locale locale) {
 			return AbstractNotificationContentDescriptorFactory.this.renderComponent(
-					() -> createComponent("htmlComponent"),
+					// we can't ensure that component and class match with available generic information
+					IOfflineComponentProvider.<Component>fromSupplier(() -> createComponent("htmlComponent"), (Class) (Object) getComponentClass()),
 					locale
 			);
 		}
 		
 		public abstract Component createComponent(String wicketId);
+		
+		public abstract Class<? extends Component> getComponentClass();
 		
 		@Override
 		public INotificationContentDescriptor withContext(INotificationRecipient recipient) {

--- a/igloo/igloo-components/igloo-component-wicket-more/src/main/java/org/iglooproject/wicket/more/notification/service/AbstractWicketRendererServiceImpl.java
+++ b/igloo/igloo-components/igloo-component-wicket-more/src/main/java/org/iglooproject/wicket/more/notification/service/AbstractWicketRendererServiceImpl.java
@@ -4,9 +4,10 @@ import java.util.Locale;
 
 import org.apache.wicket.Component;
 import org.apache.wicket.Page;
-import org.iglooproject.functional.SerializableSupplier2;
 import org.iglooproject.jpa.security.service.IRunAsSystemService;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import igloo.wicket.offline.IOfflineComponentProvider;
 
 public abstract class AbstractWicketRendererServiceImpl extends AbstractOfflinePanelRendererServiceImpl {
 	
@@ -18,16 +19,16 @@ public abstract class AbstractWicketRendererServiceImpl extends AbstractOfflineP
 	}
 	
 	@Override
-	protected String renderComponent(final SerializableSupplier2<Component> componentSupplier, final Locale locale, final String variation) {
+	protected String renderComponent(final IOfflineComponentProvider<? extends Component> offlineComponent, final Locale locale, final String variation) {
 		return securityService.runAsSystem(
-			() -> AbstractWicketRendererServiceImpl.super.renderComponent(componentSupplier, locale, variation)
+			() -> AbstractWicketRendererServiceImpl.super.renderComponent(offlineComponent, locale, variation)
 		);
 	}
 	
 	@Override
-	protected String renderPage(final SerializableSupplier2<? extends Page> pageSupplier, final Locale locale, final String variation) {
+	protected String renderPage(final IOfflineComponentProvider<? extends Page> offlineComponent, final Locale locale, final String variation) {
 		return securityService.runAsSystem(
-			() -> AbstractWicketRendererServiceImpl.super.renderPage(pageSupplier, locale, variation)
+			() -> AbstractWicketRendererServiceImpl.super.renderPage(offlineComponent, locale, variation)
 		);
 	}
 }

--- a/igloo/igloo-components/igloo-component-wicket-select2/pom.xml
+++ b/igloo/igloo-components/igloo-component-wicket-select2/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-wicket-select2</artifactId>

--- a/igloo/igloo-components/igloo-component-wicket-test/pom.xml
+++ b/igloo/igloo-components/igloo-component-wicket-test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-wicket-test</artifactId>

--- a/igloo/igloo-components/igloo-component-wicket/pom.xml
+++ b/igloo/igloo-components/igloo-component-wicket/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-component-wicket</artifactId>

--- a/igloo/igloo-components/igloo-component-wicket/src/main/java/igloo/wicket/offline/IOfflineComponentProvider.java
+++ b/igloo/igloo-components/igloo-component-wicket/src/main/java/igloo/wicket/offline/IOfflineComponentProvider.java
@@ -1,0 +1,32 @@
+package igloo.wicket.offline;
+
+import org.iglooproject.functional.SerializableSupplier2;
+
+/**
+ * Wrap component supplier and component class information for an offline wicket rendering, It can be useful to
+ * know component type before object is constructed by the supplier (needed to provide bootstrap version context
+ * based on Bootstrap interface markers, as bootstrap version needs to be added to RequestCycle before object is
+ * created).
+ */
+public interface IOfflineComponentProvider<T> {
+
+	public T getComponent();
+
+	public Class<T> getComponentClass();
+
+	public static <T> IOfflineComponentProvider<T> fromSupplier(final SerializableSupplier2<T> supplier, Class<T> componentClass) {
+			return new IOfflineComponentProvider<T>() {
+
+				@Override
+				public T getComponent() {
+					return supplier.get();
+				}
+
+				@Override
+				public Class<T> getComponentClass() {
+					return componentClass;
+				}
+			};
+	}
+
+}

--- a/igloo/igloo-components/igloo-component-wicket/src/main/java/igloo/wicket/offline/OfflineComponentClassMetadataKey.java
+++ b/igloo/igloo-components/igloo-component-wicket/src/main/java/igloo/wicket/offline/OfflineComponentClassMetadataKey.java
@@ -1,0 +1,17 @@
+package igloo.wicket.offline;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.MetaDataKey;
+import org.apache.wicket.request.cycle.RequestCycle;
+
+/**
+ * Key holding rendered page/component class in {@link RequestCycle#getMetaData(MetaDataKey)} when we perform offline rendering
+ * with igloo <code>AbstractOfflinePanelRendererServiceImpl</code> (wicket-more).
+ */
+public class OfflineComponentClassMetadataKey extends MetaDataKey<Class<? extends Component>> {
+
+	private static final long serialVersionUID = 9166675647023302325L;
+
+	public static final OfflineComponentClassMetadataKey INSTANCE = new OfflineComponentClassMetadataKey();
+
+}

--- a/igloo/igloo-components/igloo-hibernate/pom.xml
+++ b/igloo/igloo-components/igloo-hibernate/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 	
 	<groupId>org.iglooproject.components</groupId>

--- a/igloo/igloo-components/igloo-jpa-model/pom.xml
+++ b/igloo/igloo-components/igloo-jpa-model/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 	
 	<groupId>org.iglooproject.components</groupId>

--- a/igloo/igloo-components/igloo-monitoring-page/pom.xml
+++ b/igloo/igloo-components/igloo-monitoring-page/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-monitoring-page</artifactId>

--- a/igloo/igloo-components/igloo-spring-autoconfigure/pom.xml
+++ b/igloo/igloo-components/igloo-spring-autoconfigure/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-spring-autoconfigure</artifactId>
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.iglooproject.components</groupId>
 			<artifactId>igloo-component-jpa</artifactId>
-			<version>5.0.2</version>
+			<version>5.0.3-SNAPSHOT</version>
 			<optional>true</optional>
 		</dependency>
 		
@@ -50,41 +50,41 @@
 		<dependency>
 			<groupId>org.iglooproject.components</groupId>
 			<artifactId>igloo-component-flyway-8</artifactId>
-			<version>5.0.2</version>
+			<version>5.0.3-SNAPSHOT</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.iglooproject.components</groupId>
 			<artifactId>igloo-component-flyway-common</artifactId>
-			<version>5.0.2</version>
+			<version>5.0.3-SNAPSHOT</version>
 			<optional>true</optional>
 		</dependency>
 		
 		<dependency>
 			<groupId>org.iglooproject.components</groupId>
 			<artifactId>igloo-component-wicket-bootstrap5</artifactId>
-			<version>5.0.2</version>
+			<version>5.0.3-SNAPSHOT</version>
 			<optional>true</optional>
 		</dependency>
 		
 		<dependency>
 			<groupId>org.iglooproject.components</groupId>
 			<artifactId>igloo-component-wicket-bootstrap4</artifactId>
-			<version>5.0.2</version>
+			<version>5.0.3-SNAPSHOT</version>
 			<optional>true</optional>
 		</dependency>
 		
 		<dependency>
 			<groupId>org.iglooproject.components</groupId>
 			<artifactId>igloo-component-wicket-console</artifactId>
-			<version>5.0.2</version>
+			<version>5.0.3-SNAPSHOT</version>
 			<optional>true</optional>
 		</dependency>
 		
 		<dependency>
 			<groupId>org.iglooproject.components</groupId>
 			<artifactId>igloo-component-config-test</artifactId>
-			<version>5.0.2</version>
+			<version>5.0.3-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		

--- a/igloo/igloo-components/jpa-test-patterns/pom.xml
+++ b/igloo/igloo-components/jpa-test-patterns/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>jpa-test-patterns</artifactId>

--- a/igloo/igloo-components/jpa-test/pom.xml
+++ b/igloo/igloo-components/jpa-test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>jpa-test</artifactId>

--- a/igloo/igloo-components/pom.xml
+++ b/igloo/igloo-components/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.parents</groupId>
 		<artifactId>igloo-parent-maven-configuration-core</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 		<relativePath>../igloo-parents/igloo-parent-maven-configuration-core/pom.xml</relativePath>
 	</parent>
 	

--- a/igloo/igloo-components/storage-api/pom.xml
+++ b/igloo/igloo-components/storage-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>storage-api</artifactId>

--- a/igloo/igloo-components/storage-impl/pom.xml
+++ b/igloo/igloo-components/storage-impl/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>storage-impl</artifactId>

--- a/igloo/igloo-components/storage-integration/pom.xml
+++ b/igloo/igloo-components/storage-integration/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>storage-integration</artifactId>

--- a/igloo/igloo-components/storage-micrometer/pom.xml
+++ b/igloo/igloo-components/storage-micrometer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>storage-micrometer</artifactId>

--- a/igloo/igloo-components/storage-model/pom.xml
+++ b/igloo/igloo-components/storage-model/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.components</groupId>
 		<artifactId>igloo-components</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>storage-model</artifactId>

--- a/igloo/igloo-integration/igloo-integration-elasticsearch/pom.xml
+++ b/igloo/igloo-integration/igloo-integration-elasticsearch/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.integration</groupId>
 		<artifactId>igloo-integration</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloo-integration-elasticsearch</artifactId>

--- a/igloo/igloo-integration/pom.xml
+++ b/igloo/igloo-integration/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.parents</groupId>
 		<artifactId>igloo-parent-maven-configuration-core</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 		<relativePath>../igloo-parents/igloo-parent-maven-configuration-core/pom.xml</relativePath>
 	</parent>
 	

--- a/igloo/igloo-parents/igloo-parent-core-project/pom.xml
+++ b/igloo/igloo-parents/igloo-parent-core-project/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.parents</groupId>
 		<artifactId>igloo-parent-maven-configuration-core</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 		<relativePath>../igloo-parent-maven-configuration-core/pom.xml</relativePath>
 	</parent>
 	

--- a/igloo/igloo-parents/igloo-parent-maven-configuration-common/pom.xml
+++ b/igloo/igloo-parents/igloo-parent-maven-configuration-common/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.iglooproject.parents</groupId>
 	<artifactId>igloo-parent-maven-configuration-common</artifactId>
-	<version>5.0.2</version>
+	<version>5.0.3-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Igloo - Parent - Maven configuration - Common</name>

--- a/igloo/igloo-parents/igloo-parent-maven-configuration-common/pom.xml
+++ b/igloo/igloo-parents/igloo-parent-maven-configuration-common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject</groupId>
 		<artifactId>plugins-all</artifactId>
-		<version>5.0.0</version>
+		<version>5.0.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 

--- a/igloo/igloo-parents/igloo-parent-maven-configuration-core/pom.xml
+++ b/igloo/igloo-parents/igloo-parent-maven-configuration-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.parents</groupId>
 		<artifactId>igloo-parent-maven-configuration-common</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 		<relativePath>../igloo-parent-maven-configuration-common/pom.xml</relativePath>
 	</parent>
 

--- a/igloo/igloo-parents/igloo-parent-maven-configuration-core/pom.xml
+++ b/igloo/igloo-parents/igloo-parent-maven-configuration-core/pom.xml
@@ -16,8 +16,8 @@
 
 	<properties>
 		<igloo.version>${project.version}</igloo.version>
-		<igloo-maven.version>5.0.0</igloo-maven.version>
-		<igloo-commons.version>5.0.0</igloo-commons.version>
+		<igloo-maven.version>5.0.1-SNAPSHOT</igloo-maven.version>
+		<igloo-commons.version>5.0.1-SNAPSHOT</igloo-commons.version>
 
 		<igloo.log4j.major-version>2</igloo.log4j.major-version>
 		<igloo.logging.artifact>igloo-component-core-logging-log4j${igloo.log4j.major-version}</igloo.logging.artifact>

--- a/igloo/igloo-parents/pom.xml
+++ b/igloo/igloo-parents/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject</groupId>
 		<artifactId>igloo</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 	
 	<groupId>org.iglooproject.parents</groupId>

--- a/igloo/igloo-webjars/bootstrap4-override/pom.xml
+++ b/igloo/igloo-webjars/bootstrap4-override/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.webjars</groupId>
 		<artifactId>igloo-webjars</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>bootstrap4-override</artifactId>

--- a/igloo/igloo-webjars/bootstrap5-override/pom.xml
+++ b/igloo/igloo-webjars/bootstrap5-override/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.webjars</groupId>
 		<artifactId>igloo-webjars</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>bootstrap5-override</artifactId>

--- a/igloo/igloo-webjars/igloojs/pom.xml
+++ b/igloo/igloo-webjars/igloojs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.webjars</groupId>
 		<artifactId>igloo-webjars</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>igloojs</artifactId>

--- a/igloo/igloo-webjars/pom.xml
+++ b/igloo/igloo-webjars/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject.parents</groupId>
 		<artifactId>igloo-parent-maven-configuration-core</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 		<relativePath>../igloo-parents/igloo-parent-maven-configuration-core/pom.xml</relativePath>
 	</parent>
 

--- a/igloo/pom.xml
+++ b/igloo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject</groupId>
 		<artifactId>igloo-parent</artifactId>
-		<version>5.0.2</version>
+		<version>5.0.3-SNAPSHOT</version>
 	</parent>
 	
 	<artifactId>igloo</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,10 +20,10 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		
 		<maven-toolchains-plugin.version>3.1.0</maven-toolchains-plugin.version>
-		<maven-site-plugin.version>4.0.0-M1</maven-site-plugin.version>
+		<maven-site-plugin.version>4.0.0-M4</maven-site-plugin.version>
 		<igloo.wagon-ssh-external-plugin.version>3.4.1</igloo.wagon-ssh-external-plugin.version>
 		<maven-project-info-reports-plugin.version>3.4.1</maven-project-info-reports-plugin.version>
-		<igloo.owasp-maven-plugin.version>7.3.0</igloo.owasp-maven-plugin.version>
+		<igloo.owasp-maven-plugin.version>7.4.1</igloo.owasp-maven-plugin.version>
 		<igloo.versions-maven-plugin.version>2.13.0</igloo.versions-maven-plugin.version>
 	</properties>
 	

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.iglooproject</groupId>
 		<artifactId>plugins-all</artifactId>
-		<version>5.0.0</version>
+		<version>5.0.1-SNAPSHOT</version>
 	</parent>
 	
 	<artifactId>igloo-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	
 	<artifactId>igloo-parent</artifactId>
-	<version>5.0.2</version>
+	<version>5.0.3-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	
 	<name>Igloo - Parent</name>


### PR DESCRIPTION
This is a proposal to fix an issue when offline rendering is done on a
bootstrap component.

This fix needs to address two problems:

* An alternative way to set on RequestCycle the root component / page class
  rendered, so that BootstrapRequestCycle can determine a bootstrap
  version
* Allow component-and-not-page rendering to declare a bootstrap version

This proposal:

* Modify AbstractOfflinePanelRendererServiceImpl API to replace
  `Supplier<Component>` by a new `IOfflineComponentProvider`; it allows
  to known page/component type before instantiation
* Modify AbstractOfflinePanelRendererServiceImpl rendering code to setup
  a RequestCycle OfflineComponentClassMetadataKey metadata that contains
  the page/component type
* Add a warning in AbstractOfflinePanelRendererServiceImpl if rendered
  component is not consistent with advertised type
* Add IBootstrap{4,5}Component to allow to mark root component for
  offline mail generation
* Modify NotificationContentDescriptorFactoryImpl so that it can provide
  the expected notification component type
* Modify BootstrapRequestCycle to use OfflineComponentClassMetadataKey
  as a fallback for bootstrap version lookup
* Update basic-application notification example

This fix implies:
* to rewrite renderPage/renderComponent calls to replace the supplier by
  a IOfflineComponentProvider; `IOfflineComponentProvider#fromSupplier`
  is a helper to easily rewrite old calls
* add a getComponentClass on your AbstractNotificationContentDescriptorFactory
  implementations