### PR TITLE
Locale/timezone/charset check

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,7 @@ image:
 
 variables:
   MAVEN_OPTS: "-Xmx1536m"
+  JAVA_TOOL_OPTIONS: "-Duser.language=fr -Duser.country=FR -Duser.timezone=Europe/Paris -Dfile.encoding=UTF-8"
 
 stages:
   # build includes tests

--- a/igloo/igloo-components/igloo-component-spring/src/main/java/org/iglooproject/spring/autoconfigure/PropertyIdsAutoConfiguration.java
+++ b/igloo/igloo-components/igloo-component-spring/src/main/java/org/iglooproject/spring/autoconfigure/PropertyIdsAutoConfiguration.java
@@ -1,5 +1,6 @@
 package org.iglooproject.spring.autoconfigure;
 
+import org.iglooproject.spring.config.util.LocaleTimeZoneCharsetCheckerListener;
 import org.iglooproject.spring.property.dao.IImmutablePropertyDao;
 import org.iglooproject.spring.property.dao.IMutablePropertyDao;
 import org.iglooproject.spring.property.dao.ImmutablePropertyDaoImpl;
@@ -9,6 +10,7 @@ import org.iglooproject.spring.property.service.PropertyServiceImpl;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 
 @Configuration
 public class PropertyIdsAutoConfiguration {
@@ -28,5 +30,11 @@ public class PropertyIdsAutoConfiguration {
   @Bean
   public IConfigurablePropertyService propertyService() {
     return new PropertyServiceImpl();
+  }
+
+  @Bean
+  public LocaleTimeZoneCharsetCheckerListener localeTimeZoneCheckerListener(
+      Environment environment) {
+    return new LocaleTimeZoneCharsetCheckerListener(environment);
   }
 }

--- a/igloo/igloo-components/igloo-component-spring/src/main/java/org/iglooproject/spring/config/util/LocaleTimeZoneCharsetCheckerListener.java
+++ b/igloo/igloo-components/igloo-component-spring/src/main/java/org/iglooproject/spring/config/util/LocaleTimeZoneCharsetCheckerListener.java
@@ -1,0 +1,64 @@
+package org.iglooproject.spring.config.util;
+
+import java.nio.charset.Charset;
+import java.util.Locale;
+import java.util.TimeZone;
+import org.iglooproject.spring.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.core.env.Environment;
+
+public class LocaleTimeZoneCharsetCheckerListener
+    implements ApplicationListener<ContextRefreshedEvent> {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(LocaleTimeZoneCharsetCheckerListener.class);
+
+  private final Environment environment;
+
+  public LocaleTimeZoneCharsetCheckerListener(Environment environment) {
+    this.environment = environment;
+  }
+
+  @Override
+  public void onApplicationEvent(ContextRefreshedEvent event) {
+    Locale defaultLocale = Locale.getDefault();
+    TimeZone defaultTimeZone = TimeZone.getDefault();
+    Charset defaultCharset = Charset.defaultCharset();
+
+    String expectedLocale = environment.getProperty("igloo.checks.locale");
+    String expectedTimeZone = environment.getProperty("igloo.checks.timezone");
+    String expectedCharset = environment.getProperty("igloo.checks.charset");
+
+    if (expectedLocale != null && StringUtils.hasText(expectedLocale)) {
+      LOGGER.info("Checking locale {} with expected value {}", defaultLocale, expectedLocale);
+      if (!defaultLocale.toString().equalsIgnoreCase(expectedLocale)) {
+        throw new IllegalStateException(
+            String.format(
+                "Unexpected default locale %s (expected %s); setup with -Duser.language= and -Duser.country or igloo.checks.locale",
+                defaultLocale.toString(), expectedLocale));
+      }
+    }
+    if (expectedTimeZone != null && StringUtils.hasText(expectedTimeZone)) {
+      LOGGER.info(
+          "Checking timezone {} with expected value {}", defaultTimeZone.getID(), expectedTimeZone);
+      if (!defaultTimeZone.getID().equalsIgnoreCase(expectedTimeZone)) {
+        throw new IllegalStateException(
+            String.format(
+                "Unexpected default timezone %s (expected %s); setup with user -Duser.timezone= or igloo.checks.timezone",
+                defaultTimeZone.getID(), expectedTimeZone));
+      }
+    }
+    if (expectedCharset != null && StringUtils.hasText(expectedCharset)) {
+      LOGGER.info("Checking charset {} with expected value {}", defaultCharset, expectedCharset);
+      if (!defaultCharset.toString().equalsIgnoreCase(expectedCharset)) {
+        throw new IllegalStateException(
+            String.format(
+                "Unexpected default charset %s (expected %s); setup with user -Dfile.encoding= or igloo.checks.charset",
+                defaultCharset.toString(), expectedCharset));
+      }
+    }
+  }
+}

--- a/igloo/igloo-components/igloo-component-spring/src/main/resources/igloo-component-spring.properties
+++ b/igloo/igloo-components/igloo-component-spring/src/main/resources/igloo-component-spring.properties
@@ -3,3 +3,7 @@ igloo.version=${igloo.component-spring.Implementation-Version}
 igloo.build.user.name=${igloo.component-spring.Built-By}
 igloo.build.date=${igloo.component-spring.Built-Date}
 igloo.build.sha=${igloo.component-spring.Implementation-Build}
+
+igloo.checks.locale=fr_FR
+igloo.checks.timezone=Europe/Paris
+igloo.checks.charset=UTF-8

--- a/igloo/igloo-components/igloo-component-spring/src/test/java/test/TestLocaleTimezoneCharset.java
+++ b/igloo/igloo-components/igloo-component-spring/src/test/java/test/TestLocaleTimezoneCharset.java
@@ -1,0 +1,84 @@
+package test;
+
+import java.nio.charset.Charset;
+import java.util.Locale;
+import java.util.TimeZone;
+import org.assertj.core.api.Assertions;
+import org.iglooproject.spring.config.util.LocaleTimeZoneCharsetCheckerListener;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+/** Il n'est pas possible dans les tests de basculer le charset au runtime. */
+class TestLocaleTimezoneCharset {
+
+  @Test
+  void test_ok() {
+    var environment = new MockEnvironment();
+    environment.setProperty("igloo.checks.locale", "fr_FR");
+    environment.setProperty("igloo.checks.timezone", "Europe/Paris");
+    var checker = new LocaleTimeZoneCharsetCheckerListener(environment);
+
+    Locale.setDefault(Locale.FRANCE);
+    TimeZone.setDefault(TimeZone.getTimeZone("Europe/Paris"));
+    Assertions.assertThatCode(() -> checker.onApplicationEvent(null)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void test_charset_ok() {
+    var environment = new MockEnvironment();
+    environment.setProperty("igloo.checks.charset", Charset.defaultCharset().toString());
+    var checker = new LocaleTimeZoneCharsetCheckerListener(environment);
+
+    Assertions.assertThatCode(() -> checker.onApplicationEvent(null)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void test_empty_ignored() {
+    var environment = new MockEnvironment();
+    environment.setProperty("igloo.checks.locale", "  ");
+    environment.setProperty("igloo.checks.timezone", "  ");
+    environment.setProperty("igloo.checks.charset", "  ");
+    var checker = new LocaleTimeZoneCharsetCheckerListener(environment);
+
+    Assertions.assertThatCode(() -> checker.onApplicationEvent(null)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void test_locale_failure() {
+    var environment = new MockEnvironment();
+    environment.setProperty("igloo.checks.locale", "fr_FR");
+    var checker = new LocaleTimeZoneCharsetCheckerListener(environment);
+
+    Locale.setDefault(Locale.ENGLISH);
+    Assertions.assertThatCode(() -> checker.onApplicationEvent(null))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("-Duser.language")
+        .hasMessageContaining("-Duser.country")
+        .hasMessageContaining("igloo.checks.locale");
+  }
+
+  @Test
+  void test_timezone_failure() {
+    var environment = new MockEnvironment();
+    environment.setProperty("igloo.checks.timezone", "Europe/Paris");
+    var checker = new LocaleTimeZoneCharsetCheckerListener(environment);
+
+    TimeZone.setDefault(TimeZone.getTimeZone("Europe/London"));
+    Assertions.assertThatCode(() -> checker.onApplicationEvent(null))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("-Duser.timezone")
+        .hasMessageContaining("igloo.checks.timezone");
+  }
+
+  @Test
+  void test_charset_failure() {
+    var environment = new MockEnvironment();
+    environment.setProperty("igloo.checks.charset", "ISO-8859-1");
+    var checker = new LocaleTimeZoneCharsetCheckerListener(environment);
+
+    Assertions.assertThatCode(() -> checker.onApplicationEvent(null))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("-Dfile.encoding")
+        .hasMessageContaining("igloo.checks.charset");
+  }
+}


### PR DESCRIPTION
Add an automatic check for default locale/timezone/charset to ensure determinist behavior.

Checks are controlled by igloo.checks.locale, igloo.checks.timezone, igloo.checks.charset. Empty values disable checks.