### PR TITLE
Use testcontainers for basic-application tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,6 +37,7 @@ maven-build:
   services:
     - name: postgres:14
       alias: postgresql
+    - name: docker:dind
   variables:
     POSTGRES_USER: igloo_test
     POSTGRES_PASSWORD: igloo_test
@@ -47,6 +48,12 @@ maven-build:
     TEST_DB_TYPE: postgresql
     TEST_DB_HOST: postgresql
     TEST_DB_PORT: 5432
+    # Instruct Testcontainers to use the daemon of DinD, use port 2375 for non-tls connections.
+    DOCKER_HOST: "tcp://docker:2375"
+    # Instruct Docker not to start over TLS.
+    DOCKER_TLS_CERTDIR: ""
+    # Improve performance with overlayfs.
+    DOCKER_DRIVER: overlay2
 
 maven-dependencies:
   stage: dependencies

--- a/basic-application/basic-application-back/src/test/java/test/core/AbstractBasicApplicationTestCase.java
+++ b/basic-application/basic-application-back/src/test/java/test/core/AbstractBasicApplicationTestCase.java
@@ -1,78 +1,49 @@
 package test.core;
 
-import basicapp.back.business.announcement.service.business.IAnnouncementService;
-import basicapp.back.business.history.service.IHistoryLogService;
-import basicapp.back.business.referencedata.service.ICityService;
-import basicapp.back.business.role.service.IRoleService;
 import basicapp.back.business.user.model.User;
 import basicapp.back.business.user.service.business.IUserService;
 import java.util.Set;
 import org.iglooproject.jpa.exception.SecurityServiceException;
 import org.iglooproject.jpa.exception.ServiceException;
-import org.iglooproject.jpa.more.business.referencedata.model.GenericReferenceData;
-import org.iglooproject.jpa.more.business.referencedata.service.IGenericReferenceDataSubService;
-import org.iglooproject.jpa.more.business.upgrade.service.IDataUpgradeRecordService;
-import org.iglooproject.spring.property.dao.IMutablePropertyDao;
-import org.iglooproject.spring.property.service.IPropertyService;
 import org.iglooproject.test.jpa.junit.AbstractTestCase;
+import org.iglooproject.test.jpa.junit.SetupAndCleanDatabaseTestExecutionListener;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.security.acls.domain.PermissionFactory;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlMergeMode;
 
+@TestExecutionListeners(
+    value = {SetupAndCleanDatabaseTestExecutionListener.class},
+    mergeMode =
+        TestExecutionListeners.MergeMode
+            .MERGE_WITH_DEFAULTS // Retains default TestExecutionListeners.
+    )
+@Sql(scripts = "/scripts/init-data-test.sql")
+@SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
 public abstract class AbstractBasicApplicationTestCase extends AbstractTestCase {
 
-  @Autowired protected IUserService userService;
-
-  @Autowired protected ICityService cityService;
-
-  @Autowired protected IPropertyService propertyService;
-
-  @Autowired protected IDataUpgradeRecordService dataUpgradeRecordService;
-
-  @Autowired private IMutablePropertyDao mutablePropertyDao;
-
-  @Autowired private IHistoryLogService historyLogService;
-
-  @Autowired protected IRoleService roleService;
-
-  @Autowired protected IAnnouncementService announcementService;
-
-  @Autowired protected PasswordEncoder passwordEncoder;
+  public static final String BASIC_USERNAME_WITH_PERMISSIONS = "BASIC_USERNAME_WITH_PERMISSIONS";
+  public static final String ADMIN_USERNAME = "ADMIN_USERNAME";
+  public static final String BASIC_USERNAME_WITHOUT_PERMISSIONS =
+      "BASIC_USERNAME_WITHOUT_PERMISSIONS";
 
   @Autowired protected TestEntityDatabaseHelper entityDatabaseHelper;
 
-  @Autowired protected PermissionFactory permissionFactory;
-
-  @Autowired
-  @Qualifier("authenticationManager")
-  protected AuthenticationManager authenticationManager;
+  @Autowired protected IUserService userService;
 
   @BeforeEach
   @Override
   public void init() throws ServiceException, SecurityServiceException {
-    super.init();
+    clearCaches();
   }
 
+  @AfterEach
   @Override
-  protected void cleanAll() throws ServiceException, SecurityServiceException {
-    cleanEntities(historyLogService);
-    cleanEntities(userService);
-    cleanEntities(dataUpgradeRecordService);
-    cleanEntities(roleService);
-    cleanEntities(announcementService);
-
-    mutablePropertyDao.cleanInTransaction();
-  }
-
-  protected static <E extends GenericReferenceData<?, ?>> void cleanReferenceData(
-      IGenericReferenceDataSubService service, Class<E> clazz)
-      throws ServiceException, SecurityServiceException {
-    for (E entity : service.list(clazz)) {
-      service.delete(entity);
-    }
+  public void close() throws ServiceException, SecurityServiceException {
+    // Database cleaning performed by CleanDatabaseTestExecutionListener
+    // nothing to do
   }
 
   protected User addPermissions(User user, String... permissions)

--- a/basic-application/basic-application-back/src/test/java/test/core/business/user/TestUserService.java
+++ b/basic-application/basic-application-back/src/test/java/test/core/business/user/TestUserService.java
@@ -4,8 +4,6 @@ import static basicapp.back.security.model.BasicApplicationPermissionConstants.G
 import static basicapp.back.security.model.BasicApplicationPermissionConstants.GLOBAL_REFERENCE_DATA_WRITE;
 import static basicapp.back.security.model.BasicApplicationPermissionConstants.GLOBAL_ROLE_READ;
 import static basicapp.back.security.model.BasicApplicationPermissionConstants.GLOBAL_ROLE_WRITE;
-import static basicapp.back.security.model.BasicApplicationPermissionConstants.GLOBAL_USER_READ;
-import static basicapp.back.security.model.BasicApplicationPermissionConstants.GLOBAL_USER_WRITE;
 import static basicapp.back.security.model.BasicApplicationPermissionConstants.USER_EDIT_PASSWORD;
 
 import basicapp.back.business.role.model.Role;
@@ -13,8 +11,6 @@ import basicapp.back.business.user.model.User;
 import basicapp.back.business.user.model.atomic.UserType;
 import basicapp.back.business.user.service.controller.IUserControllerService;
 import com.google.common.collect.ImmutableSortedSet;
-import java.time.LocalDate;
-import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -22,47 +18,20 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.util.DateUtil;
 import org.iglooproject.jpa.exception.SecurityServiceException;
 import org.iglooproject.jpa.exception.ServiceException;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.security.test.context.support.TestExecutionEvent;
 import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.jdbc.Sql;
 import test.core.AbstractBasicApplicationTestCase;
 import test.core.config.spring.SpringBootTestBasicApplication;
 
 @SpringBootTestBasicApplication
 class TestUserService extends AbstractBasicApplicationTestCase {
 
-  private static final String BASIC_USERNAME_WITH_PERMISSIONS = "BASIC_USERNAME_WITH_PERMISSIONS";
-  private static final String ADMIN_USERNAME = "ADMIN_USERNAME";
-  private static final String BASIC_USERNAME_WITHOUT_PERMISSIONS =
-      "BASIC_USERNAME_WITHOUT_PERMISSIONS";
-
   @Autowired private IUserControllerService userControllerService;
-
-  @Override
-  @BeforeEach
-  public void init() throws SecurityServiceException, ServiceException {
-    super.init();
-    entityDatabaseHelper.createUser(
-        u -> {
-          u.setUsername(BASIC_USERNAME_WITHOUT_PERMISSIONS);
-          u.setType(UserType.BASIC);
-        },
-        true);
-    entityDatabaseHelper.createUser(u -> u.setUsername(ADMIN_USERNAME), true);
-    addPermissions(
-        entityDatabaseHelper.createUser(
-            u -> {
-              u.setUsername(BASIC_USERNAME_WITH_PERMISSIONS);
-              u.setType(UserType.BASIC);
-            },
-            true),
-        GLOBAL_USER_WRITE,
-        GLOBAL_USER_READ);
-  }
 
   @Nested
   class saveUser {
@@ -126,30 +95,14 @@ class TestUserService extends AbstractBasicApplicationTestCase {
     }
 
     @WithUserDetails(value = ADMIN_USERNAME, setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @Sql(scripts = {"/scripts/user-test.sql"})
     @Test
     void testUpdateUser() throws SecurityServiceException, ServiceException {
-      User user =
-          entityDatabaseHelper.createUser(
-              u -> {
-                u.setUsername("test");
-                u.setFirstName("firstname");
-                u.setLastName("lastname");
-              },
-              true);
-      user.setCreationDate(
-          LocalDate.of(2024, 1, 1).atStartOfDay(ZoneId.systemDefault()).toInstant());
-      user.setLastUpdateDate(
-          LocalDate.of(2024, 1, 1).atStartOfDay(ZoneId.systemDefault()).toInstant());
-      user.getPasswordInformation()
-          .setLastUpdateDate(
-              LocalDate.of(2024, 1, 1).atStartOfDay(ZoneId.systemDefault()).toInstant());
-
-      userService.flush();
       entityManagerReset();
-      User userToUpdate = userService.getById(user.getId());
-      userToUpdate.setFirstName("updatedFirstname");
-      userToUpdate.setLastName("updatedFirstname");
-      userControllerService.saveTechnicalUser(userToUpdate, "newPassword");
+      User user = userService.getById(-4L);
+      user.setFirstName("updatedFirstname");
+      user.setLastName("updatedFirstname");
+      userControllerService.saveTechnicalUser(user, "newPassword");
       entityManagerReset();
       User userBdd = userService.getById(user.getId());
       Assertions.assertThat(userBdd.getUsername()).isEqualTo("test");

--- a/basic-application/basic-application-back/src/test/java/test/core/config/spring/BasicApplicationCoreTestCommonConfig.java
+++ b/basic-application/basic-application-back/src/test/java/test/core/config/spring/BasicApplicationCoreTestCommonConfig.java
@@ -3,6 +3,7 @@ package test.core.config.spring;
 import basicapp.back.config.spring.BasicApplicationCoreCommonConfiguration;
 import org.iglooproject.jpa.more.rendering.service.EmptyRendererServiceImpl;
 import org.iglooproject.jpa.more.rendering.service.IRendererService;
+import org.iglooproject.test.jpa.junit.PSQLTestContainerConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -11,7 +12,7 @@ import test.core.TestCorePackage;
 import test.core.TestEntityDatabaseHelper;
 
 @Configuration
-@Import({BasicApplicationCoreCommonConfiguration.class})
+@Import({BasicApplicationCoreCommonConfiguration.class, PSQLTestContainerConfiguration.class})
 @ComponentScan(basePackageClasses = TestCorePackage.class)
 public class BasicApplicationCoreTestCommonConfig {
 

--- a/basic-application/basic-application-back/src/test/resources/configuration-env-test.properties
+++ b/basic-application/basic-application-back/src/test/resources/configuration-env-test.properties
@@ -5,12 +5,17 @@
 environment.configurationType=development
 environment=testing
 
-spring.datasource.url=jdbc:postgresql://${TEST_DB_HOST:localhost}:${TEST_DB_PORT:5436}/${TEST_DB_NAME:basic_application_test}
-spring.datasource.username=${TEST_DB_USER:basic_application_test}
-spring.datasource.password=${TEST_DB_PASSWORD:basic_application_test}
-spring.jpa.properties.hibernate.default_schema=${TEST_DB_USER:basic_application_test}
-spring.flyway.defaultSchema=${TEST_DB_USER:basic_application_test}
-db.schema=${TEST_DB_USER:basic_application_test}
+spring.jpa.properties.hibernate.default_schema=basic_application_test
+spring.flyway.defaultSchema=basic_application_test
+db.schema=basic_application_test
+
+spring.flyway.clean-disabled=false
+
+testContainer.database.name=basic_application_test
+testContainer.database.userName=basic_application_test
+testContainer.database.password=basic_application_test
+testContainer.database.exposedPorts=5432
+testContainer.database.dockerImageName=postgres:17-alpine
 
 environment.data.path=${TEST_DATA_PATH:/data/services/test/basic-application}
 

--- a/basic-application/basic-application-back/src/test/resources/log4j2-env-test.properties
+++ b/basic-application/basic-application-back/src/test/resources/log4j2-env-test.properties
@@ -1,3 +1,6 @@
+# Testcontainers logs (docker container setup/teardown during tests)
+logger.tc.name=tc
+logger.tc.level=INFO
 
 #logger.flyway.name=org.flywaydb
 #logger.flyway.level=DEBUG

--- a/basic-application/basic-application-back/src/test/resources/scripts/announcement-test.sql
+++ b/basic-application/basic-application-back/src/test/resources/scripts/announcement-test.sql
@@ -1,0 +1,11 @@
+insert into announcement (id, creation_date, creation_subject_label, creation_subject_reference_id,
+                          creation_subject_reference_type, description_fr, enabled,
+                          interruption_enddatetime, interruption_startdatetime, modification_date,
+                          modification_subject_label, modification_subject_reference_id,
+                          modification_subject_reference_type, publication_enddatetime,
+                          publication_startdatetime, title_fr, "type")
+values (-1, '2024-01-01 00:00:00.000', 'User{id=3, username=BASIC_USERNAME_WITH_PERMISSIONS}', 3,
+        'basicapp.back.business.user.model.User', 'testDescription', true, '2024-01-02 10:00:00.000',
+        '2024-01-01 10:00:00.000', '2024-01-01 00:00:00.000', 'User{id=3, username=BASIC_USERNAME_WITH_PERMISSIONS}', 3,
+        'basicapp.back.business.user.model.User', '2024-01-02 10:00:00.000', '2024-01-01 10:00:00.000',
+        'testTitre', 'SERVICE_INTERRUPTION');

--- a/basic-application/basic-application-back/src/test/resources/scripts/init-data-test.sql
+++ b/basic-application/basic-application-back/src/test/resources/scripts/init-data-test.sql
@@ -1,0 +1,30 @@
+insert into role (id, title)
+values (-1, 'Default');
+
+insert into role_permissions (role_id, permissions)
+values (-1, 'GLOBAL_ROLE_READ'),
+       (-1, 'GLOBAL_ANNOUNCEMENT_WRITE'),
+       (-1, 'GLOBAL_ROLE_WRITE'),
+       (-1, 'GLOBAL_REFERENCE_DATA_WRITE'),
+       (-1, 'GLOBAL_ANNOUNCEMENT_READ'),
+       (-1, 'GLOBAL_USER_READ'),
+       (-1, 'GLOBAL_USER_WRITE'),
+       (-1, 'GLOBAL_REFERENCE_DATA_READ');
+
+insert into user_ (id, creationdate, enabled, lastupdatedate,
+                   passwordhash, username, email, firstname, lastname,
+                   announcementinformation_open,
+                   "type")
+values (-1, '2024-09-27 14:55:47.143', true, '2024-09-27 14:55:47.143',
+        '{bcrypt}$2a$10$ii8ZZCYp9rt04V6Qawn1b.7MpQrd022rMr4sUTcJFCpc9ra8EL0Iu', 'BASIC_USERNAME_WITHOUT_PERMISSIONS',
+        'user1@kobalt.fr', 'user1', 'user1', true, 'BASIC'),
+       (-2, '2024-09-27 14:55:47.575', true, '2024-09-27 14:55:47.575',
+        '{bcrypt}$2a$10$cvNfP3PFWq1jnIlXf8W4Y.KruhmBY31Gcc4pIG7B/Ocxq8Au0xkwa', 'ADMIN_USERNAME', 'user2@kobalt.fr',
+        'user2', 'user2', true, 'TECHNICAL'),
+       (-3, '2024-09-27 14:55:47.708', true, '2024-09-27 14:55:47.785',
+        '{bcrypt}$2a$10$04tR9JXLBZ2TefixidU5j.6HCn5r.IE7w8vc0VJpvzcJg4vGm6bXa', 'BASIC_USERNAME_WITH_PERMISSIONS',
+        'user3@kobalt.fr', 'user3', 'user3', true, 'BASIC');
+
+INSERT INTO user__role (users_id, roles_id) VALUES
+    (-3,-1);
+

--- a/basic-application/basic-application-back/src/test/resources/scripts/user-test.sql
+++ b/basic-application/basic-application-back/src/test/resources/scripts/user-test.sql
@@ -1,0 +1,7 @@
+insert into user_ (id, creationdate, enabled, lastupdatedate, passwordhash, username, email, firstname,
+                   lastname, announcementinformation_open,
+                   passwordinformation_lastupdatedate,
+                   "type")
+values (-4, '2024-01-01 00:00:00.000', true, '2024-01-01 00:00:00.000',
+        '{bcrypt}$2a$10$bvtE8RTbt15W4mGKn9LuZ.mwn93VqGcO0/Eyk5EFVJ28UOb2mZaCi', 'test', 'user1@kobalt.fr', 'firstname',
+        'lastname', true, '2024-01-01 00:00:00.000', 'TECHNICAL');

--- a/basic-application/basic-application-front/pom.xml
+++ b/basic-application/basic-application-front/pom.xml
@@ -174,6 +174,14 @@
 			<groupId>com.google.code.findbugs</groupId>
 			<artifactId>jsr305</artifactId>
 		</dependency>
+
+		<!--test-containers-->
+		<dependency>
+			<groupId>org.iglooproject.components</groupId>
+			<artifactId>igloo-component-jpa-test</artifactId>
+			<version>${igloo.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	
 	<build>

--- a/basic-application/basic-application-front/src/test/java/test/web/AbstractBasicApplicationWebappTestCase.java
+++ b/basic-application/basic-application-front/src/test/java/test/web/AbstractBasicApplicationWebappTestCase.java
@@ -1,9 +1,6 @@
 package test.web;
 
-import basicapp.back.business.history.service.IHistoryLogService;
-import basicapp.back.business.role.service.IRoleService;
 import basicapp.back.business.user.model.User;
-import basicapp.back.business.user.model.atomic.UserType;
 import basicapp.back.business.user.service.business.IUserService;
 import basicapp.back.security.service.IBasicApplicationAuthenticationService;
 import java.util.Set;
@@ -13,13 +10,26 @@ import org.apache.wicket.protocol.http.WebApplication;
 import org.iglooproject.jpa.exception.SecurityServiceException;
 import org.iglooproject.jpa.exception.ServiceException;
 import org.iglooproject.spring.property.dao.IMutablePropertyDao;
+import org.iglooproject.test.jpa.junit.SetupAndCleanDatabaseTestExecutionListener;
 import org.iglooproject.test.wicket.core.AbstractWicketTestCase;
 import org.iglooproject.wicket.more.AbstractCoreSession;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlMergeMode;
 import test.core.TestEntityDatabaseHelper;
 
+@TestExecutionListeners(
+    value = {SetupAndCleanDatabaseTestExecutionListener.class},
+    mergeMode =
+        TestExecutionListeners.MergeMode
+            .MERGE_WITH_DEFAULTS // Retains default TestExecutionListeners.
+    )
+@Sql(scripts = "/scripts/init-data-wicket-test.sql")
+@SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
 public abstract class AbstractBasicApplicationWebappTestCase
     extends AbstractWicketTestCase<BasicApplicationWicketTester> {
 
@@ -29,13 +39,9 @@ public abstract class AbstractBasicApplicationWebappTestCase
 
   protected User administrator;
 
-  private static int userUniqueToken = 0;
-
   @Autowired protected IUserService userService;
 
   @Autowired protected IBasicApplicationAuthenticationService authenticationService;
-
-  @Autowired protected IHistoryLogService historyLogService;
 
   @Autowired protected PasswordEncoder passwordEncoder;
 
@@ -45,22 +51,23 @@ public abstract class AbstractBasicApplicationWebappTestCase
 
   @Autowired private TestEntityDatabaseHelper entityDatabaseHelper;
 
-  @Autowired private IRoleService roleService;
-
   @BeforeEach
-  public void setUp() throws ServiceException, SecurityServiceException {
-    initUsers();
-
+  @Override
+  public void init() throws ServiceException, SecurityServiceException {
+    cleanAll();
     setWicketTester(new BasicApplicationWicketTester(application));
+    initUsers();
+  }
+
+  @Override
+  @AfterEach
+  public void close() {
+    // nothing to do
   }
 
   @Override
   protected void cleanAll() throws ServiceException, SecurityServiceException {
     entityManagerClear();
-
-    cleanEntities(userService);
-    cleanEntities(historyLogService);
-    cleanEntities(roleService);
 
     mutablePropertyDao.cleanInTransaction();
 
@@ -69,23 +76,9 @@ public abstract class AbstractBasicApplicationWebappTestCase
     emptyIndexes();
   }
 
-  private void initUsers() throws ServiceException, SecurityServiceException {
-    basicUser =
-        entityDatabaseHelper.createUser(
-            u -> {
-              u.setType(UserType.BASIC);
-              u.setUsername("basicUser");
-            },
-            true);
-
-    entityDatabaseHelper.createUser(
-        u -> {
-          u.setType(UserType.BASIC);
-          u.setUsername("basicUser2");
-        },
-        true);
-
-    administrator = entityDatabaseHelper.createUser(u -> u.setUsername("technicalUser"), true);
+  private void initUsers() {
+    basicUser = userService.getByUsername("basicUser");
+    administrator = userService.getByUsername("technicalUser");
   }
 
   protected void addPermissions(User user, String... permissions)

--- a/basic-application/basic-application-front/src/test/java/test/web/config/spring/BasicApplicationWebappTestCommonConfig.java
+++ b/basic-application/basic-application-front/src/test/java/test/web/config/spring/BasicApplicationWebappTestCommonConfig.java
@@ -1,15 +1,14 @@
 package test.web.config.spring;
 
 import basicapp.front.config.spring.BasicApplicationWebappConfig;
+import org.iglooproject.test.jpa.junit.PSQLTestContainerConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import test.core.TestEntityDatabaseHelper;
 
 @Configuration
-@Import({
-  BasicApplicationWebappConfig.class,
-})
+@Import({BasicApplicationWebappConfig.class, PSQLTestContainerConfiguration.class})
 public class BasicApplicationWebappTestCommonConfig {
 
   @Bean

--- a/basic-application/basic-application-front/src/test/resources/configuration-env-test.properties
+++ b/basic-application/basic-application-front/src/test/resources/configuration-env-test.properties
@@ -7,12 +7,17 @@
 environment.configurationType=development
 environment=testing
 
-spring.datasource.url=jdbc:postgresql://${TEST_DB_HOST:localhost}:${TEST_DB_PORT:5436}/${TEST_DB_NAME:basic_application_test}
-spring.datasource.username=${TEST_DB_USER:basic_application_test}
-spring.datasource.password=${TEST_DB_PASSWORD:basic_application_test}
-spring.jpa.properties.hibernate.default_schema=${TEST_DB_USER:basic_application_test}
-spring.flyway.defaultSchema=${TEST_DB_USER:basic_application_test}
-db.schema=${TEST_DB_USER:basic_application_test}
+spring.jpa.properties.hibernate.default_schema=basic_application_test
+spring.flyway.defaultSchema=basic_application_test
+db.schema=basic_application_test
+
+spring.flyway.clean-disabled=false
+
+testContainer.database.name=basic_application_test
+testContainer.database.userName=basic_application_test
+testContainer.database.password=basic_application_test
+testContainer.database.exposedPorts=5432
+testContainer.database.dockerImageName=postgres:15-alpine
 
 environment.data.path=${TEST_DATA_PATH:/data/services/test/basic-application}
 

--- a/basic-application/basic-application-front/src/test/resources/log4j2-env-test.properties
+++ b/basic-application/basic-application-front/src/test/resources/log4j2-env-test.properties
@@ -1,0 +1,3 @@
+# Testcontainers logs (docker container setup/teardown during tests)
+logger.tc.name=tc
+logger.tc.level=INFO

--- a/basic-application/basic-application-front/src/test/resources/scripts/init-data-wicket-test.sql
+++ b/basic-application/basic-application-front/src/test/resources/scripts/init-data-wicket-test.sql
@@ -1,0 +1,13 @@
+insert into basic_application_test.user_ (id, creationdate, enabled, lastupdatedate, locale,
+                                          passwordhash, username, email, firstname, lastname,
+                                          announcementinformation_open,
+                                          "type")
+values (-1, '2024-09-27 17:10:29.287', true, '2024-09-27 17:10:29.287', 'fr',
+        '{bcrypt}$2a$10$fSKK9CAACyoXgvAdOelBVeC1Yt6jjDYjOvvST3gIG1OdwbkY/xCLS', 'basicUser', 'user1@kobalt.fr', 'user1',
+        'user1', true, 'BASIC'),
+       (-2, '2024-09-27 17:10:29.555', true, '2024-09-27 17:10:29.555', 'fr',
+        '{bcrypt}$2a$10$bd4OdJRn2BNBjXNdEUo0RexB81QatFPSb1rlPWolBSCoO8UdFvCoK', 'basicUser2', 'user2@kobalt.fr',
+        'user2', 'user2', true, 'BASIC'),
+       (-3, '2024-09-27 17:10:29.669', true, '2024-09-27 17:10:29.669', 'fr',
+        '{bcrypt}$2a$10$jKdBem7jpJ6hjVoyx4nPO.xOeAcKnQILlUWV8NajOnZgRZXTARXEO', 'technicalUser', 'user3@kobalt.fr',
+        'user3', 'user3', true, 'TECHNICAL');

--- a/igloo/igloo-components/igloo-component-jpa-test/pom.xml
+++ b/igloo/igloo-components/igloo-component-jpa-test/pom.xml
@@ -135,6 +135,20 @@
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 		</dependency>
+		
+		<!--test-containers-->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-testcontainers</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>postgresql</artifactId>
+		</dependency>
 	</dependencies>
 	
 	<build>

--- a/igloo/igloo-components/igloo-component-jpa-test/src/main/java/org/iglooproject/test/jpa/junit/AbstractTestCase.java
+++ b/igloo/igloo-components/igloo-component-jpa-test/src/main/java/org/iglooproject/test/jpa/junit/AbstractTestCase.java
@@ -55,7 +55,8 @@ public abstract class AbstractTestCase {
   @Autowired(required = false)
   private IHibernateSearchService hibernateSearchService;
 
-  protected abstract void cleanAll() throws ServiceException, SecurityServiceException;
+  /** Override to clean database with services (without flyway) */
+  protected void cleanAll() throws ServiceException, SecurityServiceException {}
 
   protected static <E extends GenericEntity<?, ? super E>> void cleanEntities(
       IGenericEntityService<?, E> service) throws ServiceException, SecurityServiceException {
@@ -165,7 +166,7 @@ public abstract class AbstractTestCase {
    * and it can be cached only at first retrieval. This behavior lead to unexpected and inconsistent
    * result in TestCache.
    */
-  private void clearCaches() {
+  protected void clearCaches() {
     ((SessionImpl) getEntityManager().getDelegate())
         .getSessionFactory()
         .getCache()

--- a/igloo/igloo-components/igloo-component-jpa-test/src/main/java/org/iglooproject/test/jpa/junit/PSQLTestContainerConfiguration.java
+++ b/igloo/igloo-components/igloo-component-jpa-test/src/main/java/org/iglooproject/test/jpa/junit/PSQLTestContainerConfiguration.java
@@ -1,0 +1,37 @@
+package org.iglooproject.test.jpa.junit;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+public class PSQLTestContainerConfiguration {
+
+  @Value("${testContainer.database.name}")
+  String databaseName;
+
+  @Value("${testContainer.database.userName}")
+  String username;
+
+  @Value("${testContainer.database.password}")
+  String password;
+
+  @Value("${testContainer.database.exposedPorts}")
+  String exposedPorts;
+
+  @Value("${testContainer.database.dockerImageName}")
+  String dockerImageName;
+
+  @Bean
+  @ServiceConnection
+  public PostgreSQLContainer<?> postgreSQLContainer() { // NOSONAR
+    try (PostgreSQLContainer<?> container = new PostgreSQLContainer<>(dockerImageName)) {
+      return container
+          .withDatabaseName(databaseName)
+          .withUsername(username)
+          .withPassword(password)
+          .withExposedPorts(Integer.parseInt(exposedPorts))
+          .withReuse(true);
+    }
+  }
+}

--- a/igloo/igloo-components/igloo-component-jpa-test/src/main/java/org/iglooproject/test/jpa/junit/SetupAndCleanDatabaseTestExecutionListener.java
+++ b/igloo/igloo-components/igloo-component-jpa-test/src/main/java/org/iglooproject/test/jpa/junit/SetupAndCleanDatabaseTestExecutionListener.java
@@ -1,0 +1,34 @@
+package org.iglooproject.test.jpa.junit;
+
+import jakarta.validation.constraints.NotNull;
+import org.flywaydb.core.Flyway;
+import org.springframework.core.Ordered;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.TestExecutionListener;
+
+/**
+ * Reinitializes a Flyway-managed test database by cleaning it before applying all migrations. The
+ * re-initialization is performed before each test method is run.
+ *
+ * <p>This listener implies that {@link Flyway} bean is registered in spring context.
+ *
+ * <p>An alternative to a TestExecutionListener would be a setup method annotated with @BeforeEach
+ * that invokes Flyway. But then you would lose the ability to access the database in any
+ * TestExecutionListener (including the one that processes @Sql annotations) because @BeforeEach
+ * runs after the TestExecutionListeners.
+ */
+public class SetupAndCleanDatabaseTestExecutionListener implements TestExecutionListener, Ordered {
+  @Override
+  public void beforeTestMethod(@NotNull TestContext testContext) {
+    Flyway flyway = testContext.getApplicationContext().getBean(Flyway.class);
+    flyway.clean();
+    flyway.migrate();
+  }
+
+  @Override
+  public int getOrder() {
+    // Ensures that this TestExecutionListener is run before SqlScriptsTestExecutionListener which
+    // handles @Sql.
+    return 5000 - 1000; // 5000 = SqlScriptsTestExecutionListener#order
+  }
+}


### PR DESCRIPTION
This PR uses spring-boot and test-containers integration to ease test running.

Two helpers are added to `igloo-component-jpa-test` :
* A TestExecutionListener to perform database init/teardown with Flyway. With this setup, dropping entities during test teardown is unneeded.
* A spring config class to bind test-containers and spring-boot configuration

In basic-application test, spring config and execution listener are added, and common database initialization are moved to SQL initialization in place of java service initialization. Database manual cleaning is removed. It is still possible to use non-sql / java pattern if needed.